### PR TITLE
Declare peer dependencies over plugins

### DIFF
--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -21,5 +21,9 @@
     "babel-eslint": "^10.0.3",
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-react-hooks": "^2.5.0"
+  },
+  "peerDependencies": {
+    "eslint-plugin-react": "^7.17.0",
+    "eslint-plugin-react-hooks": "^2.5.0"
   }
 }


### PR DESCRIPTION
Dependencies in custom configs over (ESLint) plugins must be declared as `peersDependencies`, if not, fresh installs could fail as the plugin(s) would be installed as a transitive dependency, and not direct to the app as required (for instance) by ESLint.

> See: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/package.json
 and https://nodejs.org/es/blog/npm/peer-dependencies/#the-problem-plugins
